### PR TITLE
Pin older version of packaging to fix issue in kats

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ seaborn==0.12.0
 scipy==1.7.3
 pytube==12.1.0
 pytube3==9.6.4
+# Pin older version of packaging to fix issue in kats:
+packaging==21.3 


### PR DESCRIPTION
There is a [runtime issue on space](https://huggingface.co/spaces/RTL/videomatch?logs=container), a quick google search [suggested this might help](https://stackoverflow.com/questions/74766701/error-while-using-kats-module-packaging-version-has-no-attribute-legacyversion).